### PR TITLE
Change tag compare method for rdm_tagged_bw

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -1837,7 +1837,13 @@ ssize_t ft_rx(struct fid_ep *ep, size_t size)
 static inline int ft_tag_is_valid(struct fid_cq * cq, struct fi_cq_err_entry *comp,
 				  uint64_t tag)
 {
-	if ((hints->caps & FI_TAGGED) && (cq == rxcq) && (comp->tag != tag)) {
+	if (opts.options & FT_OPT_BW) {
+		if ((hints->caps & FI_TAGGED) && (cq == rxcq) &&
+			((comp->tag >= tag + opts.window_size / 2) || (comp->tag + opts.window_size / 2 <= tag))) {
+			return 0;
+		}
+	}
+	else if ((hints->caps & FI_TAGGED) && (cq == rxcq) && (comp->tag != tag)) {
 		FT_ERR("Tag mismatch!. Expected: %"PRIu64", actual: %"PRIu64, tag, comp->tag);
 		return 0;
 	}


### PR DESCRIPTION
Sometimes completions may not be reported in order. rdm_tagged_bw will
fail when that occur, because it expect them in correct order. As it is
benchmark test it doesn't need strict tag validation. This changes
compare method to check if arrived tag is in range of window size.

Signed-off-by: Marcin Salnik <marcin.salnik@intel.com>